### PR TITLE
Updated the link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ This doc assumes that
 ## Microclimate Instructions
 
 * Prereq 1: [Install Microclimate](https://microclimate-dev2ops.github.io/installlocally)
-* Prereq 2: [Install IBM Cloud Private.](https://www.ibm.com/support/knowledgecenter/en/SSBS6K_2.1.0.3/installing/installing.html)
-	* **Note:** Choose and install the version of IBM Cloud Private that Microclimate supports. 
+* Prereq 2: [Install IBM Cloud Private.](https://www.ibm.com/support/knowledgecenter/en/SSBS6K_3.1.0/installing/installing.html)
 * Prereq 3: [Install Microclimate on IBM Cloud Private.](https://github.com/IBM/charts/blob/master/stable/ibm-microclimate/README.md)
 
 * Import the following microservices into Microclimate with [Importing projects](https://microclimate-dev2ops.github.io/importingaproject):


### PR DESCRIPTION
I updated the IBM Cloud Private link on line 83 because the newest docs were recently released. With the updated link, I think that we can remove the note that was originally underneath the link.