### PR TITLE
Enable CORS with Open Liberty

### DIFF
--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -19,7 +19,6 @@
   
   <cors domain="/acmeair"
       allowedOrigins="*"
-      allowedMethods="GET, DELETE, POST"
       allowedMethods="OPTIONS, GET, DELETE, POST"
       allowedHeaders="*"
       allowCredentials="true"

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -16,4 +16,13 @@
     <!-- enable visibility to third party apis -->
     <classloader apiTypeVisibility="api,ibm-api,spec,stable,third-party"/>
   </webApplication>
+  
+  <cors domain="/acmeair"
+      allowedOrigins="*"
+      allowedMethods="GET, DELETE, POST"
+      allowedMethods="OPTIONS, GET, DELETE, POST"
+      allowedHeaders="*"
+      allowCredentials="true"
+      maxAge="3600" />
+  
 </server>


### PR DESCRIPTION
Enabled CORS with domain "/acmeair" to allow requests from other Acme Air services. Allows all origins and all headers. 