### PR TITLE
Update version of maven-compiler-plugin in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,12 @@
   </properties>
   <build>
     <plugins>
+      <!-- Use a later version than the default that doesn't use log4j -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+      </plugin>
       <!-- Enable liberty-maven plugin -->
       <plugin>
         <groupId>io.openliberty.tools</groupId>


### PR DESCRIPTION
We got a security issue flagged as log4j-1.2.12.jar was found on our systems. We tracked it down to being caused by maven during the AcmeAir builds as explained here -> https://stackoverflow.com/questions/70473780/why-is-maven-downloading-log4j-1-2-12-jar . This change stops it downloading log4j.